### PR TITLE
Memory cache to promote a increase performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3507,3 +3507,5 @@ Retornar a mensagem "Fullstack Challenge 🏅 - Space X API"
 - [x] Map instead of reduce.
 - [x] Map instead of foreach.
 - [x] Create test for this file.
+- [x] Using bulkWrite of mongoose.
+- [ ] Memory management to reduce API Space X calls.

--- a/README.md
+++ b/README.md
@@ -3508,4 +3508,4 @@ Retornar a mensagem "Fullstack Challenge 🏅 - Space X API"
 - [x] Map instead of foreach.
 - [x] Create test for this file.
 - [x] Using bulkWrite of mongoose.
-- [ ] Memory management to reduce API Space X calls.
+- [x] Memory management to reduce API Space X calls.

--- a/src/utils/api/spaceX/listLaunches.ts
+++ b/src/utils/api/spaceX/listLaunches.ts
@@ -1,16 +1,27 @@
+import { launchesInMemory } from "../../memoryCache";
 import { SpaceXLaunches } from "../../spaceX";
+
+export const getLaunches = async () => {
+  if (!launchesInMemory.hasItem("launchesBySpaceXAPI")) {
+    const launches =
+      process.env.NODE_ENV === "test"
+        ? (
+            (await (
+              await fetch("https://api.spacexdata.com/v5/launches")
+            ).json()) as Array<SpaceXLaunches>
+          ).filter((_, index) => index < 5)
+        : ((await (
+            await fetch("https://api.spacexdata.com/v5/launches")
+          ).json()) as Array<SpaceXLaunches>);
+    // storeExpiringItem(key: string, value: SpaceXLaunches[], timeToLiveInSecs: number)
+    launchesInMemory.storeExpiringItem("launchesBySpaceXAPI", launches, 10);
+  }
+  return launchesInMemory.retrieveItemValue("launchesBySpaceXAPI");
+};
 
 export const fetchLaunches: () => Promise<Array<SpaceXLaunches>> = async () => {
   try {
-    return process.env.NODE_ENV === "test"
-      ? (
-          (await (
-            await fetch("https://api.spacexdata.com/v5/launches")
-          ).json()) as Array<SpaceXLaunches>
-        ).filter((_, index) => index < 5)
-      : ((await (
-          await fetch("https://api.spacexdata.com/v5/launches")
-        ).json()) as Array<SpaceXLaunches>);
+    return await getLaunches();
   } catch (error) {
     throw new Error(error.message);
   }

--- a/src/utils/api/spaceX/listRockets.ts
+++ b/src/utils/api/spaceX/listRockets.ts
@@ -1,20 +1,34 @@
 import dayjs from "dayjs";
 import { generateRandomColor } from "../../generateColor";
 import { RocketType, SpaceXLaunches } from "../../spaceX";
+import { rocketsInMemory } from "../../memoryCache";
+
+const getRockets = async () => {
+  if (!rocketsInMemory.hasItem("rocketsBySpaceXAPI")) {
+    const rockets = (
+      (await (
+        await fetch("https://api.spacexdata.com/v4/rockets")
+      ).json()) as Array<RocketType>
+    ).map((rocket) => ({
+      color: "rgb(255,0,0)",
+      launches: [],
+      name: rocket.name,
+      id: rocket.id,
+    }));
+    // storeExpiringItem(key: string, value: SpaceXLaunches[], timeToLiveInSecs: number)
+    rocketsInMemory.storeExpiringItem(
+      "rocketsBySpaceXAPI",
+      rockets as Array<RocketType>,
+      10
+    );
+  }
+  return rocketsInMemory.retrieveItemValue("rocketsBySpaceXAPI");
+};
 
 export const fetchRockets: (
   launches: Array<SpaceXLaunches>
 ) => Promise<Array<RocketType>> = async (launches) => {
-  const rockets = (
-    (await (
-      await fetch("https://api.spacexdata.com/v4/rockets")
-    ).json()) as Array<RocketType>
-  ).map((rocket) => ({
-    color: "rgb(255,0,0)",
-    launches: [],
-    name: rocket.name,
-    id: rocket.id,
-  }));
+  const rockets = await getRockets();
 
   const rocketsWithLaunches = rockets.map((rocket, index, self) => {
     return {

--- a/src/utils/getDataFromSpaceXAPI.ts
+++ b/src/utils/getDataFromSpaceXAPI.ts
@@ -1,6 +1,6 @@
 import { LaunchModel } from "../models/Launch";
 import { SpaceXLaunches } from "./spaceX";
-import { lastLaunches } from "./memoryCache";
+import { lastLaunchesInMemory } from "./memoryCache";
 
 // Methods to get data from space x public api
 export const getDataFromSpaceX: () => Promise<
@@ -8,7 +8,7 @@ export const getDataFromSpaceX: () => Promise<
 > = async () => {
   try {
     // Verifing if has data from space x api on cache
-    if (!lastLaunches.hasItem("lastLaunchInSpaceX")) {
+    if (!lastLaunchesInMemory.hasItem("lastLaunchInSpaceX")) {
       const launchData = await fetch(
         "https://api.spacexdata.com/v5/launches/latest"
       );
@@ -17,7 +17,7 @@ export const getDataFromSpaceX: () => Promise<
       const launch = (await launchData.json()) as SpaceXLaunches;
 
       // Set at cache the data from space x api
-      lastLaunches.storeExpiringItem(
+      lastLaunchesInMemory.storeExpiringItem(
         "lastLaunchInSpaceX",
         launch,
         60 * 60 /* 1 hour */
@@ -25,22 +25,22 @@ export const getDataFromSpaceX: () => Promise<
     }
 
     // Verifing if has data from mongoDB on cache
-    if (!lastLaunches.hasItem("lastLaunchInDB")) {
-      lastLaunches.storePermanentItem(
+    if (!lastLaunchesInMemory.hasItem("lastLaunchInDB")) {
+      lastLaunchesInMemory.storePermanentItem(
         "lastLaunchInDB",
         await LaunchModel.findOne({
-          id: lastLaunches.retrieveItemValue("lastLaunchInSpaceX").id,
+          id: lastLaunchesInMemory.retrieveItemValue("lastLaunchInSpaceX").id,
         })
       );
     }
 
     const launchAlreadyExists =
-      lastLaunches.retrieveItemValue("lastLaunchInDB");
+      lastLaunchesInMemory.retrieveItemValue("lastLaunchInDB");
 
     // if dont exist, create
     if (launchAlreadyExists === null) {
       await LaunchModel.create(
-        lastLaunches.retrieveItemValue("lastLaunchInSpaceX")
+        lastLaunchesInMemory.retrieveItemValue("lastLaunchInSpaceX")
       );
       return "data pushed from spacex api";
     }

--- a/src/utils/memoryCache.ts
+++ b/src/utils/memoryCache.ts
@@ -1,11 +1,26 @@
 import { MemoryCache } from "memory-cache-node";
-import { SpaceXLaunches } from "./spaceX";
+import { RocketType, SpaceXLaunches } from "./spaceX";
 
 /* Creates a memory cache for items which has string keys and Launch values. Memory cache checks expiring items every 1 seconds. The maximum number of items in the cache is 2. */
 const ITEMSEXPIRATIONCHECKINTERVALINSECS = 1; // seconds
 const MAXITEMCOUNT = 2;
 
-export const lastLaunches = new MemoryCache<string, SpaceXLaunches>(
+export const lastLaunchesInMemory = new MemoryCache<string, SpaceXLaunches>(
   ITEMSEXPIRATIONCHECKINTERVALINSECS,
   MAXITEMCOUNT
+);
+
+export const launchesInMemory = new MemoryCache<string, Array<SpaceXLaunches>>(
+  10, // time in seconds to expire items
+  2 // number of items
+);
+
+export const rocketsInMemory = new MemoryCache<string, Array<RocketType>>(
+  10, // time in seconds to expire items
+  2 // number of items
+);
+
+export const amountLaunchesInMemory = new MemoryCache<string, number>(
+  10, // time in seconds to expire items
+  1 // number of items
 );

--- a/src/utils/seed.ts
+++ b/src/utils/seed.ts
@@ -20,20 +20,31 @@ export const seed: () => Promise<
     const rocketsFromSpaceXAPI = await fetchRockets(launchesFromSpaceXAPI);
 
     // save at mongo database all the launches
-    await LaunchModel.insertMany(
+    await LaunchModel.bulkWrite(
       launchesFromSpaceXAPI.map((launch) => ({
-        ...launch,
-        rocket: {
-          name: rocketsFromSpaceXAPI.find(
-            (rocket) => rocket.id === launch.rocket
-          )?.name,
-          id: launch.rocket,
+        insertOne: {
+          document: {
+            ...launch,
+            rocket: {
+              name: rocketsFromSpaceXAPI.find(
+                (rocket) => rocket.id === launch.rocket
+              ).name,
+              id: launch.rocket,
+            },
+          },
         },
       }))
     );
 
     // save at mongo database all the rockets
-    await RocketModel.insertMany(rocketsFromSpaceXAPI);
+
+    await RocketModel.bulkWrite(
+      rocketsFromSpaceXAPI.map((rocket) => ({
+        insertOne: {
+          document: rocket,
+        },
+      }))
+    );
 
     return "launches pushed";
   } catch (error) {

--- a/src/utils/seed.ts
+++ b/src/utils/seed.ts
@@ -3,21 +3,39 @@ import { RocketModel } from "../models/Rocket";
 
 import { fetchLaunches } from "./api/spaceX/listLaunches";
 import { fetchRockets } from "./api/spaceX/listRockets";
+import { amountLaunchesInMemory } from "./memoryCache";
+
+export const getAmountLaunchesInDB = async () => {
+  if (!amountLaunchesInMemory.hasItem("totalLaunchesInDB")) {
+    const total = await LaunchModel.count();
+    // storeExpiringItem(key: string, value: number, timeToLiveInSecs: number)
+    amountLaunchesInMemory.storeExpiringItem("totalLaunchesInDB", total, 10);
+  }
+  return amountLaunchesInMemory.retrieveItemValue("totalLaunchesInDB");
+};
 
 export const seed: () => Promise<
   "launches are loaded" | "launches pushed"
 > = async () => {
   try {
     // get amount of Launches
-    const totalLaunches = await LaunchModel.count();
+    const totalLaunches = await getAmountLaunchesInDB();
 
     if (totalLaunches > 0) return "launches are loaded";
+
+    amountLaunchesInMemory.clear();
 
     // get launches from public api SpaceX
     const launchesFromSpaceXAPI = await fetchLaunches();
 
     // get rockets from public api SpaceX
     const rocketsFromSpaceXAPI = await fetchRockets(launchesFromSpaceXAPI);
+
+    amountLaunchesInMemory.storeExpiringItem(
+      "totalLaunchesInDB",
+      launchesFromSpaceXAPI.length,
+      10
+    );
 
     // save at mongo database all the launches
     await LaunchModel.bulkWrite(

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -2,10 +2,10 @@ import request from "supertest";
 import mongoose from "mongoose";
 
 import { app } from "../src/app";
-import { lastLaunches } from "../src/utils/memoryCache";
+import { lastLaunchesInMemory } from "../src/utils/memoryCache";
 
 afterAll(async () => {
-  lastLaunches.destroy();
+  lastLaunchesInMemory.destroy();
   await mongoose.connection.close();
   // await new Promise<void>((resolve) => setTimeout(() => resolve(), 500)); // avoid jest open handle error
 });

--- a/tests/unitary/getDataFromSpaceXAPI.test.ts
+++ b/tests/unitary/getDataFromSpaceXAPI.test.ts
@@ -1,10 +1,10 @@
 import mongoose from "mongoose";
 import { connection } from "../../src/db/conn";
 import { getDataFromSpaceX } from "../../src/utils/getDataFromSpaceXAPI";
-import { lastLaunches } from "../../src/utils/memoryCache";
+import { lastLaunchesInMemory } from "../../src/utils/memoryCache";
 
 afterAll(async () => {
-  lastLaunches.destroy();
+  lastLaunchesInMemory.destroy();
   await mongoose.connection.close();
   // await new Promise<void>((resolve) => setTimeout(() => resolve(), 500)); // avoid jest open handle error
 });

--- a/tests/unitary/seeds.test.ts
+++ b/tests/unitary/seeds.test.ts
@@ -1,74 +1,20 @@
 import mongoose from "mongoose";
 
 import { connection } from "../../src/db/conn";
-import { LaunchModel, LaunchSchema } from "../../src/models/Launch";
-import { seed } from "./../../src/utils/seed";
-
-const mockeLaunch: LaunchSchema = {
-  links: {
-    patch: {
-      small: "null",
-      large: "null",
-    },
-    reddit: {
-      campaign: "null",
-      launch: "null",
-      media: "null",
-      recovery: "null",
-    },
-    flickr: {
-      small: ["null"],
-      original: ["null"],
-    },
-    presskit: "null",
-    webcast: "null",
-    youtube_id: "null",
-    article: "null",
-    wikipedia: "null",
-  },
-  rocket: {
-    name: "Falcon 9",
-    id: "5e9d0d95eda69973a809d1ec",
-  },
-  static_fire_date_utc: "null",
-  static_fire_date_unix: 0,
-  net: false,
-  window: 0,
-  success: false,
-  failures: ["null"],
-  details: "null",
-  crew: [{ crew: "", role: "" }],
-  ships: ["null"],
-  capsules: ["null"],
-  payloads: ["null"],
-  launchpad: "5e9e4501f509094ba4566f84",
-  auto_update: true,
-  name: "ispace Mission 1 & Rashid",
-  date_utc: "2022-11-22T00:00:00.000Z",
-  date_unix: 1669075200,
-  date_local: "2022-11-21T19:00:00-05:00",
-  date_precision: "day",
-  upcoming: true,
-  cores: [
-    {
-      core: "null",
-      flight: 0,
-      gridfins: true,
-      legs: true,
-      reused: false,
-      landing_attempt: false,
-      landing_success: false,
-      landing_type: "null",
-      landpad: "null",
-    },
-  ],
-  id: "633f723d0531f07b4fdf59c4",
-  tdb: false,
-  flight_Number: 0,
-};
+import { seed } from "../../src/utils/seed";
+import {
+  amountLaunchesInMemory,
+  launchesInMemory,
+  rocketsInMemory,
+} from "../../src/utils/memoryCache";
 
 beforeAll(async () => {
   await connection();
+  await mongoose.connection.db.dropCollection("launches");
+  await mongoose.connection.db.dropCollection("rockets");
+  amountLaunchesInMemory.clear();
+  launchesInMemory.clear();
+  rocketsInMemory.clear();
 }, 10000);
 
 afterAll(async () => {
@@ -76,28 +22,23 @@ afterAll(async () => {
 });
 
 describe("Seeds files run when starting app and feed the mongodb with rockets and launches", () => {
-  test("should return message 'launches are loaded' when the seed method are called and if there're at the least one launch at database", async () => {
-    await LaunchModel.create(mockeLaunch);
+  test("should return message 'launches pushed' when the seed method are called and if there aren't launch at the database", async () => {
+    expect(launchesInMemory.hasItem("launchesBySpaceXAPI")).toBeFalsy();
+    expect(rocketsInMemory.hasItem("rocketsBySpaceXAPI")).toBeFalsy();
+    expect(amountLaunchesInMemory.hasItem("totalLaunchesInDB")).toBeFalsy();
 
-    return expect(seed()).resolves.toBe("launches are loaded");
+    const result = await seed();
+
+    expect(result).toBe("launches pushed");
+
+    expect(launchesInMemory.hasItem("launchesBySpaceXAPI")).toBeTruthy();
+    expect(rocketsInMemory.hasItem("rocketsBySpaceXAPI")).toBeTruthy();
+    return expect(
+      amountLaunchesInMemory.hasItem("totalLaunchesInDB")
+    ).toBeTruthy();
   });
 
-  test("should return message 'launches pushed' when the seed method are called and if there aren't launch at the database", async () => {
-    try {
-      await mongoose.connection.db.dropCollection("launches");
-      await mongoose.connection.db.dropCollection("rockets");
-
-      return expect(seed()).resolves.toBe("launches pushed");
-    } catch (error) {
-      console.log(error);
-    }
-  }, 12000);
-
-  test("should throw error when the mongoose is disconnected", async () => {
-    await mongoose.connection.close();
-    return expect(seed()).rejects.toHaveProperty(
-      "message",
-      "Client must be connected before running operations"
-    );
+  test("should return message 'launches are loaded' when the seed method are called and if there're at the least one launch at database", () => {
+    return expect(seed()).resolves.toBe("launches are loaded");
   });
 });

--- a/tests/utils/generateColors.test.ts
+++ b/tests/utils/generateColors.test.ts
@@ -1,9 +1,9 @@
 import mongoose from "mongoose";
 import { generateRandomColor } from "../../src/utils/generateColor";
-import { lastLaunches } from "../../src/utils/memoryCache";
+import { lastLaunchesInMemory } from "../../src/utils/memoryCache";
 
 afterAll(async () => {
-  lastLaunches.destroy();
+  lastLaunchesInMemory.destroy();
   await mongoose.connection.close();
 });
 


### PR DESCRIPTION
Both to count launch's queries in mongoDB and to fetch launches and rocket from public API Space X, the usage of memory cache promote a increase of performance.