### PR TITLE
Middleware in '/home' route

### DIFF
--- a/src/controllers/home/index.ts
+++ b/src/controllers/home/index.ts
@@ -1,12 +1,6 @@
 import { Request, Response } from "express";
-import { validationResult } from "express-validator";
 
-export const home = (req: Request, res: Response) => {
-  const errors = validationResult(req);
-
-  if (!errors.isEmpty())
-    return res.status(422).json({ errors: errors.array() });
-
+export const home = (_: Request, res: Response) => {
   try {
     return res
       .status(200)

--- a/src/middleware/home/index.ts
+++ b/src/middleware/home/index.ts
@@ -7,9 +7,10 @@ export const validationQueryParams = (
   next: NextFunction
 ) => {
   const errors = validationResult(req);
+
   // If errors return 422, client didn't provide required or unpermitted values at query parameters
-  if (!errors.isEmpty()) {
+  if (!errors.isEmpty())
     return res.status(422).json({ errors: errors.array() });
-  }
+
   return next();
 };

--- a/src/middleware/stats/pie.ts
+++ b/src/middleware/stats/pie.ts
@@ -6,8 +6,8 @@ export const resultValidationParams = (
   res: Response,
   next: NextFunction
 ) => {
-  console.log("PIE VALIDATION PARAMS");
   const errors = validationResult(req);
+  // If errors return 422, client didn't provide required or unpermitted values at query parameters
   if (!errors.isEmpty())
     return res.status(422).json({ errors: errors.array() });
   return next();

--- a/src/routes/launchesRoute.ts
+++ b/src/routes/launchesRoute.ts
@@ -2,7 +2,7 @@ import express from "express";
 import { launchesList } from "../controllers/launches";
 import { checkExact, checkSchema } from "express-validator";
 import { validationLaunchSchema } from "./validations";
-import { handleLaunch } from "@/middleware/launch/list";
+import { validationQueryParams } from "@/middleware/launch/list";
 
 const launchesRouter = express.Router();
 
@@ -11,7 +11,7 @@ launchesRouter.get(
   checkExact(checkSchema(validationLaunchSchema), {
     message: "Param not permitted",
   }),
-  (req, res, next) => handleLaunch(req, res, next),
+  (req, res, next) => validationQueryParams(req, res, next),
   launchesList
 );
 


### PR DESCRIPTION
In the '/home' route, no query parameters are permitted, so a middleware layer file is created to enforce this restriction.